### PR TITLE
Fix result limits add additional tracking parameters to product URLs

### DIFF
--- a/Model/Service/Recommendation/Category.php
+++ b/Model/Service/Recommendation/Category.php
@@ -47,6 +47,7 @@ use Nosto\Result\Graphql\Recommendation\CategoryMerchandisingResult;
 class Category
 {
     const NOSTO_PREVIEW_COOKIE = 'nostopreview';
+    const MAX_PRODUCT_AMOUNT = 100;
 
     private $logger;
     private $cookieManager;
@@ -68,13 +69,16 @@ class Category
      * @param NostoAccount $nostoAccount
      * @param $nostoCustomerId
      * @param $category
+     * @param int $limit
      * @return CategoryMerchandisingResult|null
      */
     public function getPersonalisationResult(
         NostoAccount $nostoAccount,
         $nostoCustomerId,
-        $category
+        $category,
+        $limit = self::MAX_PRODUCT_AMOUNT
     ) {
+        $limit = self::MAX_PRODUCT_AMOUNT < $limit ? self::MAX_PRODUCT_AMOUNT : $limit;
         $result = null;
         $featureAccess = new FeatureAccess($nostoAccount);
         if (!$featureAccess->canUseGraphql()) {
@@ -87,7 +91,8 @@ class Category
             $category,
             '',
             AbstractGraphQLOperation::IDENTIFIER_BY_CID,
-            $previewMode
+            $previewMode,
+            $limit
         );
 
         try {

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -232,7 +232,7 @@ class Toolbar extends Template
         /* @var Product $product */
         $collection->each(static function ($product) use ($nostoProductIds, $trackCode) {
             if (in_array($product->getId(), $nostoProductIds, true)) {
-                $product->setData(NostoProductPlugin::NOSTO_TRACKING, $trackCode);
+                $product->setData(NostoProductPlugin::NOSTO_TRACKING_PARAMETER_NAME, $trackCode);
             }
         });
     }

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -38,6 +38,7 @@ namespace Nosto\Cmp\Plugin\Catalog\Block;
 
 use Magento\Backend\Block\Template\Context;
 use Magento\Catalog\Block\Product\ProductList\Toolbar as MagentoToolbar;
+use Magento\Catalog\Model\Product;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection as FulltextCollection;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Registry;
@@ -48,14 +49,14 @@ use Magento\Store\Model\StoreManagerInterface;
 use Nosto\Cmp\Helper\CategorySorting as NostoHelperSorting;
 use Nosto\Cmp\Helper\Data as NostoCmpHelperData;
 use Nosto\Cmp\Model\Service\Recommendation\Category as CategoryRecommendation;
+use Nosto\Cmp\Plugin\Catalog\Model\Product as NostoProductPlugin;
 use Nosto\Helper\ArrayHelper as NostoHelperArray;
 use Nosto\NostoException;
+use Nosto\Result\Graphql\Recommendation\CategoryMerchandisingResult;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
 use Nosto\Tagging\Logger\Logger as NostoLogger;
 use Nosto\Tagging\Model\CategoryString\Builder as CategoryBuilder;
 use Nosto\Tagging\Model\Customer\Customer as NostoCustomer;
-use Nosto\Result\Graphql\Recommendation\CategoryMerchandisingResult;
-use Nosto\Cmp\Plugin\Catalog\Model\Product as NostoProductPlugin;
 
 class Toolbar extends Template
 {
@@ -82,6 +83,8 @@ class Toolbar extends Template
 
     /** @var NostoLogger */
     private $logger;
+
+    private static $isProcessed = false;
 
     /**
      * Toolbar constructor.
@@ -127,6 +130,9 @@ class Toolbar extends Template
     public function afterSetCollection(
         MagentoToolbar $subject
     ) {
+        if (self::$isProcessed) {
+            return $subject;
+        }
         /* @var Store $store */
         $store = $this->storeManager->getStore();
         $currentOrder = $subject->getCurrentOrder();
@@ -135,34 +141,36 @@ class Toolbar extends Template
             && $this->nostoCmpHelperData->isCategorySortingEnabled($store)
         ) {
             try {
-                $result = $this->getCmpResult($store);
                 $subjectCollection = $subject->getCollection();
+                $result = $this->getCmpResult($store, $subjectCollection);
                 if ($result instanceof CategoryMerchandisingResult
                     && $subjectCollection instanceof FulltextCollection
                 ) {
                     //Get ids of products to order
-                    $orderIds = $this->parseProductIds($result);
-                    if (!empty($orderIds)
-                        && NostoHelperArray::onlyScalarValues($orderIds)
+                    $nostoProductIds = $this->parseProductIds($result);
+                    if (!empty($nostoProductIds)
+                        && NostoHelperArray::onlyScalarValues($nostoProductIds)
                     ) {
-                        $orderIds = array_reverse($orderIds);
-                        $this->filterAndSortByProductIds($subjectCollection, $orderIds);
-                        $this->addTrackParamToProduct($subjectCollection, $result->getTrackingCode());
+                        $nostoProductIds = array_reverse($nostoProductIds);
+                        $this->sortByProductIds($subjectCollection, $nostoProductIds);
+                        $this->addTrackParamToProduct($subjectCollection, $result->getTrackingCode(), $nostoProductIds);
                     }
                 }
             } catch (\Exception $e) {
                 $this->logger->exception($e);
             }
         }
+        self::$isProcessed = true;
         return $subject;
     }
 
     /**
      * @param Store $store
+     * @param FulltextCollection $collection
      * @return CategoryMerchandisingResult|null
      * @throws NostoException
      */
-    private function getCmpResult(Store $store)
+    private function getCmpResult(Store $store, FulltextCollection $collection)
     {
         $nostoAccount = $this->nostoHelperAccount->findAccount($store);
         if ($nostoAccount === null) {
@@ -171,23 +179,26 @@ class Toolbar extends Template
         $category = $this->registry->registry('current_category');
         $categoryString = $this->categoryBuilder->build($category, $store);
         $nostoCustomer = $this->cookieManager->getCookie(NostoCustomer::COOKIE_NAME);
+        $limit = $collection->getSize();
         return $this->categoryRecommendation->getPersonalisationResult(
             $nostoAccount,
             $nostoCustomer,
-            $categoryString
+            $categoryString,
+            $limit
         );
     }
 
     /**
      * @param FulltextCollection $collection
-     * @param array $ids
+     * @param array $nostoProductIds
      */
-    private function filterAndSortByProductIds(FulltextCollection $collection, array $ids)
+    private function sortByProductIds(FulltextCollection $collection, array $nostoProductIds)
     {
         $select = $collection->getSelect();
-        $zendExpression = new \Zend_Db_Expr('e.entity_id IN ( ' . implode(',', $ids) . ' )');
-        $select->where($zendExpression);
-        $zendExpression = new \Zend_Db_Expr('FIELD(e.entity_id,' . implode(',', $ids) . ') DESC');
+        $zendExpression = [
+            new \Zend_Db_Expr('FIELD(e.entity_id,' . implode(',', $nostoProductIds) . ') DESC'),
+            new \Zend_Db_Expr($this->getSecondarySort())
+        ];
         $select->order($zendExpression);
     }
 
@@ -214,11 +225,25 @@ class Toolbar extends Template
     /**
      * @param FulltextCollection $collection
      * @param $trackCode
+     * @param array $nostoProductIds
      */
-    private function addTrackParamToProduct(FulltextCollection $collection, $trackCode)
+    private function addTrackParamToProduct(FulltextCollection $collection, $trackCode, array $nostoProductIds)
     {
-        foreach ($collection->getItems() as $item) {
-            $item[NostoProductPlugin::NOSTO_TRACKING] = $trackCode;
-        }
+        /* @var Product $product */
+        $collection->each(static function ($product) use ($nostoProductIds, $trackCode) {
+            if (in_array($product->getId(), $nostoProductIds, true)) {
+                $product->setData(NostoProductPlugin::NOSTO_TRACKING, $trackCode);
+            }
+        });
+    }
+
+    /**
+     * Returns the secondary sort defined by the merchant
+     *
+     * @return string
+     */
+    private function getSecondarySort()
+    {
+        return 'cat_index_position ASC'; // ToDo - must be selectable by the merchant
     }
 }

--- a/Plugin/Catalog/Model/Product.php
+++ b/Plugin/Catalog/Model/Product.php
@@ -40,7 +40,10 @@ use Magento\Catalog\Model\Product as MagentoProduct;
 
 class Product
 {
-    const NOSTO_TRACKING = 'nosto';
+    const NOSTO_TRACKING_PARAMETER_NAME = 'nosto';
+    const NOSTO_SOURCE_PARAMETER_NAME = 'nosto_source';
+    const NOSTO_SOURCE_PARAMETER_VALUE = 'cmp';
+    const NOSTO_PRODUCT_ID_PARAMETER_VALUE = 'nosto-pid';
 
     /**
      * @param MagentoProduct $product
@@ -49,10 +52,12 @@ class Product
      */
     public function afterGetProductUrl(MagentoProduct $product, $url)
     {
-        if ($product->getData(self::NOSTO_TRACKING) !== null) {
+        if ($product->getData(self::NOSTO_TRACKING_PARAMETER_NAME) !== null) {
             $existingParams = $this->parseExistingQueryParams($url);
             $nostoParam = [
-                self::NOSTO_TRACKING => $product->getData(self::NOSTO_TRACKING)
+                self::NOSTO_TRACKING_PARAMETER_NAME => $product->getData(self::NOSTO_TRACKING_PARAMETER_NAME),
+                self::NOSTO_SOURCE_PARAMETER_NAME => self::NOSTO_SOURCE_PARAMETER_VALUE,
+                self::NOSTO_PRODUCT_ID_PARAMETER_VALUE => $product->getId()
             ];
             $params = array_merge($existingParams, $nostoParam);
             $url = $product->getUrlModel()->getUrl($product, ['_query' => $params]);


### PR DESCRIPTION
* Add hard limit of 100 products for graphql queries
* Use Magento's collection size as limit for CMP operation  
* Add additional tracking parameters to the product URLs