### PR TITLE
Reduce the number of calls to getCurrentOrder method

### DIFF
--- a/Plugin/Catalog/Block/AbstractBlock.php
+++ b/Plugin/Catalog/Block/AbstractBlock.php
@@ -74,6 +74,9 @@ abstract class AbstractBlock extends Template
     /** @var NostoLogger */
     public $logger;
 
+    /** @var string */
+    private static $currentOrder;
+
     /**
      * AbstractBlock constructor.
      * @param Context $context
@@ -115,7 +118,6 @@ abstract class AbstractBlock extends Template
 
         $currentOrder = $this->getCurrentOrder();
         if ($currentOrder === null) {
-            $this->logger->info('Current sorting order can not be null');
             return false;
         }
         if ($currentOrder === NostoHelperSorting::NOSTO_PERSONALIZED_KEY
@@ -135,10 +137,11 @@ abstract class AbstractBlock extends Template
      */
     public function isCmpTakingOverCatalog()
     {
-        if ($this->isCmpCurrentSortOrder() && self::$totalProducts !== 0) {
-            return true;
+        if (!$this->isCmpCurrentSortOrder() ||
+            (self::$totalProducts === 0 || self::$totalProducts === null)) {
+            return false;
         }
-        return false;
+        return true;
     }
 
     /**
@@ -146,7 +149,10 @@ abstract class AbstractBlock extends Template
      */
     private function getCurrentOrder()
     {
-        return $this->paramResolver->getSortingOrder();
+        if (self::$currentOrder === null) {
+            self::$currentOrder = $this->paramResolver->getSortingOrder();
+        }
+        return self::$currentOrder;
     }
 
     /**

--- a/Plugin/Catalog/Block/AbstractBlock.php
+++ b/Plugin/Catalog/Block/AbstractBlock.php
@@ -152,7 +152,8 @@ abstract class AbstractBlock extends Template
     private function isCmpResult()
     {
         if (!$this->isCmpCurrentSortOrder() ||
-            (self::$totalProducts === 0 || self::$totalProducts === null)) {
+            (self::$totalProducts === 0 || self::$totalProducts === null)
+           ) {
             return false;
         }
         return true;

--- a/Plugin/Catalog/Block/AbstractBlock.php
+++ b/Plugin/Catalog/Block/AbstractBlock.php
@@ -75,7 +75,10 @@ abstract class AbstractBlock extends Template
     public $logger;
 
     /** @var string */
-    private static $currentOrder;
+    public static $currentOrder;
+
+    /** @var bool */
+    public static $catalogTakeover;
 
     /**
      * AbstractBlock constructor.
@@ -136,6 +139,17 @@ abstract class AbstractBlock extends Template
      * @return bool
      */
     public function isCmpTakingOverCatalog()
+    {
+        if (self::$catalogTakeover === null) {
+            self::$catalogTakeover = $this->isCmpResult();
+        }
+        return self::$catalogTakeover;
+    }
+
+    /**
+     * @return bool
+     */
+    private function isCmpResult()
     {
         if (!$this->isCmpCurrentSortOrder() ||
             (self::$totalProducts === 0 || self::$totalProducts === null)) {

--- a/Plugin/Catalog/Block/DefaultParameterResolver.php
+++ b/Plugin/Catalog/Block/DefaultParameterResolver.php
@@ -84,7 +84,7 @@ class DefaultParameterResolver implements ParameterResolverInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     private function getDefaultCategorySorting()
     {
@@ -93,6 +93,9 @@ class DefaultParameterResolver implements ParameterResolverInterface
          * @noinspection PhpDeprecationInspection
          */
         $category = $this->registry->registry('current_category');
-        return $category->getDefaultSortBy();
+        if ($category instanceof Category) {
+            return $category->getDefaultSortBy();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1 - Noticed that too many calls are made to get the current order so it's value will be stored in a static variable
2 - Fix bug when calling method on null

## Related Issue
closes #21 , #20 

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
