### PR TITLE
Introduce possibility to define max products to be fetched from Nosto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 2.0.2
+* Introduce possibility to define maximum amount of products to be fetched from Nosto to support category pages with that allow all products to be viewed   
+
 ### 2.0.1
 * Change the script type to `application/json` for category mapping
 * Add possibility to debug the category query via Magento's debug logging 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -55,6 +55,11 @@ class Data extends AbstractHelper
      */
     const XML_PATH_CATEGORY_SORTING = 'nosto_cmp/flags/category_sorting';
 
+    /**
+     * Path to the configuration object that stores the max limit for products
+     */
+    const XML_PATH_CATEGORY_MAX_PRODUCT_LIMIT = 'nosto_cmp/limit/max_products';
+
     /** @var ModuleListInterface */
     private $moduleList;
 
@@ -83,6 +88,17 @@ class Data extends AbstractHelper
     public function isCategorySortingEnabled(StoreInterface $store = null)
     {
         return (bool)$this->getStoreConfig(self::XML_PATH_CATEGORY_SORTING, $store);
+    }
+
+    /**
+     * Returns if category sorting is enabled
+     *
+     * @param StoreInterface|null $store the store model or null.
+     * @return bool the configuration value
+     */
+    public function getMaxProductLimit(StoreInterface $store = null)
+    {
+        return (int)$this->getStoreConfig(self::XML_PATH_CATEGORY_MAX_PRODUCT_LIMIT, $store);
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -94,7 +94,7 @@ class Data extends AbstractHelper
      * Returns if category sorting is enabled
      *
      * @param StoreInterface|null $store the store model or null.
-     * @return bool the configuration value
+     * @return integer
      */
     public function getMaxProductLimit(StoreInterface $store = null)
     {

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -48,6 +48,7 @@ use /** @noinspection PhpDeprecationInspection */
     Magento\Framework\Registry;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\LayeredNavigation\Block\Navigation\State;
+use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\Store;
 use Nosto\Cmp\Helper\Data as NostoCmpHelperData;
 use Nosto\Cmp\Model\Filter\FilterBuilder as NostoFilterBuilder;
@@ -289,10 +290,10 @@ class Toolbar extends AbstractBlock
 
     /**
      * @param ProductCollection $collection
-     * @param Store $store
-     * @return int|string
+     * @param StoreInterface $store
+     * @return int
      */
-    private function getPageSize(ProductCollection $collection, Store $store)
+    private function getPageSize(ProductCollection $collection, StoreInterface $store)
     {
         $pageSize = $collection->getPageSize();
         $maxLimit = $this->nostoCmpHelperData->getMaxProductLimit($store);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "require-dev": {
     "php": ">=7.1.0",
     "magento-ecg/coding-standard": "3.*",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -56,6 +56,17 @@
                     <frontend_model>Nosto\Cmp\Model\Config\Frontend\CategorySorting</frontend_model>
                 </field>
             </group>
+            <group id="limit" translate="label" type="text" sortOrder="20" showInDefault="1"
+                   showInWebsite="1" showInStore="1">
+                <label>Limits</label>
+                <field id="max_products" translate="label comment" type="text" sortOrder="200"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Max product limit</label>
+                    <comment>
+                        <![CDATA[Maximum limit for products to be fetched from Nosto in a category page. Please note that Nosto's API might have different internal limit.]]>
+                    </comment>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -7,6 +7,9 @@
             <flags>
                 <category_sorting>1</category_sorting>
             </flags>
+            <limit>
+                <max_products>1000</max_products>
+            </limit>
         </nosto>
     </default>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="2.0.1">
+    <module name="Nosto_Cmp" setup_version="2.0.2">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
## Description
Introduce possibility to define max products to be fetched from Nosto.

## Related Issue
#72

## Motivation and Context
This is needed for category pages that allow all products to be viewed on a category page.  

## How Has This Been Tested?
Tested locally with several different max limits. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
