### PR TITLE
Hotfix 2.0.3 - fix max product limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 2.0.3
+* Fix the default max product limit configuration and set the default value to be 250 which is the current max products limit in Nosto     
+
 ### 2.0.2
 * Introduce possibility to define maximum amount of products to be fetched from Nosto to support category pages with that allow all products to be viewed   
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "require-dev": {
     "php": ">=7.1.0",
     "magento-ecg/coding-standard": "3.*",

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,13 +3,13 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
-        <nosto>
+        <nosto_cmp>
             <flags>
                 <category_sorting>1</category_sorting>
             </flags>
             <limit>
-                <max_products>1000</max_products>
+                <max_products>250</max_products>
             </limit>
-        </nosto>
+        </nosto_cmp>
     </default>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="2.0.2">
+    <module name="Nosto_Cmp" setup_version="2.0.3">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
## Description
Fix getting the default max product limit for CMP graphql calls and set the default limit to be 250 which is the max limit on Nosto's end. 

## Motivation and Context
Pagination is broken if max product limit is not set.  

## How Has This Been Tested?
Tested locally

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
