### PR TITLE
Hotfix/3.1.0 rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+## 3.1.0-rc3
+* Return Magento sorting when CM call fails
+
 ### 3.1.0-rc2
 * Fix Magento products graphql query pagination issue
 

--- a/Plugin/CatalogGraphQl/Products/Query/Search.php
+++ b/Plugin/CatalogGraphQl/Products/Query/Search.php
@@ -98,7 +98,8 @@ class Search
         SearchResult  $searchResult,
         array $args
     ) {
-        if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])) {
+        if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])
+            && $this->getTotalPages() !== null) {
             return $this->searchResultFactory->create([
                 'totalCount' => $searchResult->getTotalCount(),
                 'productsSearchResult' => $searchResult->getProductsSearchResult(),
@@ -112,11 +113,14 @@ class Search
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     private function getTotalPages()
     {
         $batchModel = $this->sessionService->getBatchModel();
+        if ($batchModel === null) {
+            return null;
+        }
         return (int) ceil($batchModel->getTotalCount() / $batchModel->getLastUsedLimit());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "3.1.0-rc2",
+  "version": "3.1.0-rc3",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.0.4",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="3.1.0-rc2">
+    <module name="Nosto_Cmp" setup_version="3.1.0-rc3">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Graphql returns an error in case the cmp results are not returned. Magento's product ordering should be returned in case the cmp call is not made or failed. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
