### PR TITLE
Check customerId is not null for fetching CMP results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+## 3.1.0-rc6
+* Render magento sorting directly when Nosto customer cookie is missing
+
 ## 3.1.0-rc5
 * Render frontend layouts only when CM configuration is enabled
 * Upgrade PHP-SDK version to fix CM not displaying Nosto sorting when batchToken is null

--- a/Exception/MissingCookieException.php
+++ b/Exception/MissingCookieException.php
@@ -34,41 +34,11 @@
  *
  */
 
-namespace Nosto\Cmp\Model\Service\Recommendation;
+namespace Nosto\Cmp\Exception;
 
-use Nosto\Cmp\Exception\MissingCookieException;
-use Nosto\Cmp\Model\Filter\FiltersInterface;
 use Nosto\NostoException;
-use Nosto\Result\Graphql\Recommendation\CategoryMerchandisingResult;
 
-interface StateAwareCategoryServiceInterface
+class MissingCookieException extends NostoException
 {
-    /**
-     * @param FiltersInterface $filters
-     * @param int $pageNumber
-     * @param int $limit
-     * @return CategoryMerchandisingResult|null
-     * @throws MissingCookieException
-     * @throws NostoException
-     */
-    public function getPersonalisationResult(
-        FiltersInterface $filters,
-        $pageNumber,
-        $limit
-    ): ?CategoryMerchandisingResult;
 
-    /**
-     * @return CategoryMerchandisingResult|null
-     */
-    public function getLastResult(): ?CategoryMerchandisingResult;
-
-    /**
-     * @param $id
-     */
-    public function setCategoryInRegistry($id): void;
-
-    /**
-     * @return int
-     */
-    public function getLastUsedLimit(): int;
 }

--- a/Model/Service/Recommendation/StateAwareCategoryService.php
+++ b/Model/Service/Recommendation/StateAwareCategoryService.php
@@ -193,7 +193,6 @@ class StateAwareCategoryService implements StateAwareCategoryServiceInterface
         if ($nostoAccount === null) {
             throw new NostoException('Account cannot be null');
         }
-        if ($this->cookieManager->getCookie(NostoCustomer::COOKIE_NAME) == nu)
         $featureAccess = new FeatureAccess($nostoAccount);
         if (!$featureAccess->canUseGraphql()) {
             throw new NostoException('Missing Nosto API_APPS token');

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -45,6 +45,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\LayeredNavigation\Block\Navigation\State;
 use Magento\Store\Model\Store;
+use Nosto\Cmp\Exception\MissingCookieException;
 use Nosto\Cmp\Helper\Data as NostoCmpHelperData;
 use Nosto\Cmp\Helper\SearchEngine;
 use Nosto\Cmp\Logger\LoggerInterface;
@@ -161,6 +162,8 @@ class Toolbar extends AbstractBlock
                         $this
                     );
                 }
+            } catch (MissingCookieException $e) {
+                $this->getLogger()->debugCmp($e->getMessage(), $this);
             } catch (Exception $e) {
                 $this->getLogger()->exception($e);
             }

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -175,9 +175,10 @@ class Toolbar extends AbstractBlock
     /**
      * @param int $start starting from 0
      * @param int $limit
-     * @return CategoryMerchandisingResult
-     * @throws NostoException
+     * @return CategoryMerchandisingResult|null
      * @throws LocalizedException
+     * @throws MissingCookieException
+     * @throws NostoException
      */
     private function getCmpResult($start, $limit)
     {

--- a/Plugin/Framework/Search/Request/AbstractHandler.php
+++ b/Plugin/Framework/Search/Request/AbstractHandler.php
@@ -39,6 +39,7 @@ namespace Nosto\Cmp\Plugin\Framework\Search\Request;
 use Exception;
 use Magento\Store\Model\StoreManagerInterface;
 use Nosto\Cmp\Exception\CmpException;
+use Nosto\Cmp\Exception\MissingCookieException;
 use Nosto\Cmp\Helper\SearchEngine;
 use Nosto\Cmp\Logger\LoggerInterface;
 use Nosto\Cmp\Model\Filter\FiltersInterface;
@@ -253,6 +254,9 @@ abstract class AbstractHandler
                 $limit
             );
             return $res ? CategoryMerchandising::parseProductIds($res) : null;
+        } catch (MissingCookieException $e) {
+            $this->logger->debugCmp($e->getMessage(), $this);
+            return null;
         } catch (Exception $e) {
             $this->logger->exception($e);
             return null;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "3.1.0-rc5",
+  "version": "3.1.0-rc6",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.0.4",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="3.1.0-rc5">
+    <module name="Nosto_Cmp" setup_version="3.1.0-rc6">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In case the customer refuses personalisation cookies,  the module will make CMP calls with null customerId

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
