### PR TITLE
Hotfix 3.1.2 - Improve logging when building fitlers

### DIFF
--- a/Block/Meta.php
+++ b/Block/Meta.php
@@ -37,6 +37,7 @@
 
 namespace Nosto\Cmp\Block;
 
+use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Nosto\Cmp\Helper\Data as NostoCmpHelperData;
@@ -47,7 +48,11 @@ use Nosto\Cmp\Helper\Data as NostoCmpHelperData;
  */
 class Meta extends Template
 {
+    /** @var NostoCmpHelperData  */
     private $nostoHelperData;
+
+    /** @var Escaper */
+    public $escaper;
 
     /**
      * Constructor.
@@ -61,6 +66,7 @@ class Meta extends Template
     ) {
         parent::__construct($context);
         $this->nostoHelperData = $nostoHelperData;
+        $this->escaper = $context->getEscaper();
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.1.2
+* Improve logging for getting filter values
+
 ### 3.1.1
 * Fix version in composer file
 

--- a/Model/Filter/WebFilters.php
+++ b/Model/Filter/WebFilters.php
@@ -176,7 +176,7 @@ class WebFilters implements FiltersInterface
     private function mapValueToFilter(string $name, $value)
     {
         if ($this->brand === $name) {
-            $this->includeFilters->setBrands($this->makeArrayFromValue($value));
+            $this->includeFilters->setBrands($this->makeArrayFromValue($name, $value));
             return;
         }
 
@@ -188,7 +188,7 @@ class WebFilters implements FiltersInterface
                 $this->includeFilters->setFresh((bool)$value);
                 break;
             default:
-                $this->includeFilters->setCustomFields($name, $this->makeArrayFromValue($value));
+                $this->includeFilters->setCustomFields($name, $this->makeArrayFromValue($name, $value));
                 break;
         }
     }
@@ -210,11 +210,12 @@ class WebFilters implements FiltersInterface
     }
 
     /**
+     * @param string $name
      * @param string|int|array $value
      * @return array
      * @throws NostoException
      */
-    private function makeArrayFromValue($value)
+    private function makeArrayFromValue($name, $value)
     {
         if (is_string($value) || is_numeric($value)) {
             $value = [$value];
@@ -224,6 +225,6 @@ class WebFilters implements FiltersInterface
             return $value;
         }
 
-        throw new NostoException('Can not map value to filter');
+        throw new NostoException(sprintf('Can not get value for filter: %s', $name));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.1.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="3.1.1">
+    <module name="Nosto_Cmp" setup_version="3.1.2">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>

--- a/view/frontend/templates/meta.phtml
+++ b/view/frontend/templates/meta.phtml
@@ -39,4 +39,4 @@ use Nosto\Cmp\Block\Meta;
 /**  @var Meta $block */
 ?>
 <!-- Nosto CMP Meta Tags -->
-<meta name="nosto-cmp-version" content="<?= $block->escapeHtml($block->getModuleVersion()); ?>">
+<meta name="nosto-cmp-version" content="<?= $block->escaper->escapeHtml($block->getModuleVersion()); ?>">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the module fails to get the value of a facet/filter, it does not log the filter name, which makes it difficult to debug. 
The name of the filter is added to ease the debugging process. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
