### PR TITLE
Add fallback sorting to relevance

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -56,9 +56,14 @@ class Data extends AbstractHelper
     const XML_PATH_CATEGORY_SORTING = 'nosto_cmp/flags/category_sorting';
 
     /**
-     * Path to the configuration object that stores category sorting
+     * Path to the configuration object that stores categories mapping
      */
     const XML_PATH_CATEGORY_MAPPING = 'nosto_cmp/flags/map_all_categories';
+
+    /**
+     * Path to the configuration object that stores fallback sorting
+     */
+    const XML_PATH_FALLBACK_SORTING = 'nosto_cmp/flags/fallback_sorting';
 
     /**
      * Path to the configuration object that stores the max limit for products
@@ -97,7 +102,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Returns if category sorting is enabled
+     * Returns if mapping of all categories is enabled
      *
      * @param StoreInterface|null $store the store model or null.
      * @return bool the configuration value
@@ -108,7 +113,18 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Returns if category sorting is enabled
+     * Returns the fallback sorting
+     *
+     * @param StoreInterface|null $store the store model or null.
+     * @return string
+     */
+    public function getFallbackSorting(StoreInterface $store = null)
+    {
+        return $this->getStoreConfig(self::XML_PATH_FALLBACK_SORTING, $store);
+    }
+
+    /**
+     * Returns max product limit
      *
      * @param StoreInterface|null $store the store model or null.
      * @return integer

--- a/Model/Config/Source/FallbackSorting.php
+++ b/Model/Config/Source/FallbackSorting.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Cmp\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Framework\Phrase;
+use Magento\Catalog\Model\ResourceModel\ConfigFactory;
+use Magento\Catalog\Model\ResourceModel\Config;
+
+class FallbackSorting implements OptionSourceInterface
+{
+
+    /**
+     * @var ConfigFactory
+     */
+    private $configFactory;
+
+    /**
+     * FallbackSorting constructor.
+     */
+    public function __construct(ConfigFactory $configFactory)
+    {
+        $this->configFactory = $configFactory;
+    }
+
+
+    /**
+     * @return array|void
+     */
+    public function toOptionArray()
+    {
+        $options = [
+            //This is always hard coded
+            ['value' => 'position', 'label' => new Phrase('Position')]
+        ];
+
+        /** @var Config $config */
+        $configModel = $this->configFactory->create();
+        $attributesData = $configModel->getAttributesUsedForSortBy();
+        foreach ($attributesData as $attributeData) {
+            $attributeCode = $attributeData['attribute_code'];
+            $options[] = [
+                'value' => $attributeData['attribute_code'],
+                'label' => new Phrase($attributeData['store_label'])
+            ];
+        }
+        return $options;
+    }
+}

--- a/Model/Config/Source/FallbackSorting.php
+++ b/Model/Config/Source/FallbackSorting.php
@@ -51,12 +51,12 @@ class FallbackSorting implements OptionSourceInterface
 
     /**
      * FallbackSorting constructor.
+     * @param ConfigFactory $configFactory
      */
     public function __construct(ConfigFactory $configFactory)
     {
         $this->configFactory = $configFactory;
     }
-
 
     /**
      * @return array|void
@@ -72,7 +72,6 @@ class FallbackSorting implements OptionSourceInterface
         $configModel = $this->configFactory->create();
         $attributesData = $configModel->getAttributesUsedForSortBy();
         foreach ($attributesData as $attributeData) {
-            $attributeCode = $attributeData['attribute_code'];
             $options[] = [
                 'value' => $attributeData['attribute_code'],
                 'label' => new Phrase($attributeData['store_label'])

--- a/Plugin/Framework/Search/Request/AbstractHandler.php
+++ b/Plugin/Framework/Search/Request/AbstractHandler.php
@@ -40,6 +40,7 @@ use Exception;
 use Magento\Store\Model\StoreManagerInterface;
 use Nosto\Cmp\Exception\CmpException;
 use Nosto\Cmp\Exception\MissingCookieException;
+use Nosto\Cmp\Helper\Data as CmpHelperData;
 use Nosto\Cmp\Helper\SearchEngine;
 use Nosto\Cmp\Logger\LoggerInterface;
 use Nosto\Cmp\Model\Filter\FiltersInterface;
@@ -89,15 +90,22 @@ abstract class AbstractHandler
     private $accountHelper;
 
     /**
+     * @var CmpHelperData
+     */
+    private $cmpHelperData;
+
+    /**
      * @var StateAwareCategoryServiceInterface
      */
     protected $categoryService;
 
     /**
+     * AbstractHandler constructor.
      * @param ParameterResolverInterface $parameterResolver
      * @param SearchEngine $searchEngineHelper
      * @param StoreManagerInterface $storeManager
      * @param NostoHelperAccount $nostoHelperAccount
+     * @param CmpHelperData $cmpHelperData
      * @param StateAwareCategoryServiceInterface $categoryService
      * @param LoggerInterface $logger
      */
@@ -106,6 +114,7 @@ abstract class AbstractHandler
         SearchEngine $searchEngineHelper,
         StoreManagerInterface $storeManager,
         NostoHelperAccount $nostoHelperAccount,
+        CmpHelperData $cmpHelperData,
         StateAwareCategoryServiceInterface $categoryService,
         LoggerInterface $logger
     ) {
@@ -114,6 +123,7 @@ abstract class AbstractHandler
         $this->searchEngineHelper = $searchEngineHelper;
         $this->storeManager = $storeManager;
         $this->accountHelper = $nostoHelperAccount;
+        $this->cmpHelperData = $cmpHelperData;
         $this->categoryService = $categoryService;
     }
 
@@ -147,6 +157,7 @@ abstract class AbstractHandler
                 $this,
                 $requestData
             );
+            $this->setFallbackSort($requestData);
             return;
         }
         $this->resetRequestData($requestData);
@@ -180,6 +191,25 @@ abstract class AbstractHandler
     private function cleanUpCmpSort(array &$requestData)
     {
         unset($requestData['sort'][Search::findNostoSortingIndex($requestData)]);
+    }
+
+    /**
+     * Set fallback sort order
+     *
+     * @param array $requestData
+     */
+    private function setFallbackSort(array &$requestData)
+    {
+        try {
+            $store = $this->storeManager->getStore();
+            $this->cmpHelperData->getFallbackSorting($store);
+            $requestData['sort'][] = [
+                'field' => 'price',
+                'direction' => 'ASC'
+            ];
+        } catch (Exception $e) {
+            $this->logger->debugCmp(sprintf("Could not set fallback sorting. %s", $e->getMessage()), $this);
+        }
     }
 
     /**

--- a/Plugin/Framework/Search/Request/AbstractHandler.php
+++ b/Plugin/Framework/Search/Request/AbstractHandler.php
@@ -202,9 +202,9 @@ abstract class AbstractHandler
     {
         try {
             $store = $this->storeManager->getStore();
-            $this->cmpHelperData->getFallbackSorting($store);
+            $sorting = $this->cmpHelperData->getFallbackSorting($store);
             $requestData['sort'][] = [
-                'field' => 'price',
+                'field' => $sorting,
                 'direction' => 'ASC'
             ];
         } catch (Exception $e) {

--- a/Plugin/Framework/Search/Request/GraphQlHandler.php
+++ b/Plugin/Framework/Search/Request/GraphQlHandler.php
@@ -38,6 +38,7 @@ namespace Nosto\Cmp\Plugin\Framework\Search\Request;
 
 use Magento\Store\Model\StoreManagerInterface;
 use Nosto\Cmp\Exception\CmpException;
+use Nosto\Cmp\Helper\Data as CmpHelperData;
 use Nosto\Cmp\Helper\SearchEngine;
 use Nosto\Cmp\Logger\LoggerInterface;
 use Nosto\Cmp\Model\Filter\GraphQlFilters;
@@ -62,6 +63,7 @@ class GraphQlHandler extends AbstractHandler
      * @param SearchEngine $searchEngineHelper
      * @param StoreManagerInterface $storeManager
      * @param NostoHelperAccount $nostoHelperAccount
+     * @param CmpHelperData $cmpHelperData
      * @param StateAwareCategoryServiceInterface $categoryService
      * @param SessionService $sessionService
      * @param LoggerInterface $logger
@@ -72,6 +74,7 @@ class GraphQlHandler extends AbstractHandler
         SearchEngine $searchEngineHelper,
         StoreManagerInterface $storeManager,
         NostoHelperAccount $nostoHelperAccount,
+        CmpHelperData $cmpHelperData,
         StateAwareCategoryServiceInterface $categoryService,
         SessionService $sessionService,
         LoggerInterface $logger
@@ -81,6 +84,7 @@ class GraphQlHandler extends AbstractHandler
             $searchEngineHelper,
             $storeManager,
             $nostoHelperAccount,
+            $cmpHelperData,
             $categoryService,
             $logger
         );

--- a/Plugin/Framework/Search/Request/WebHandler.php
+++ b/Plugin/Framework/Search/Request/WebHandler.php
@@ -40,6 +40,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\LayeredNavigation\Block\Navigation\State;
 use Magento\Store\Model\StoreManagerInterface;
+use Nosto\Cmp\Helper\Data as CmpHelperData;
 use Nosto\Cmp\Helper\SearchEngine;
 use Nosto\Cmp\Logger\LoggerInterface;
 use Nosto\Cmp\Model\Filter\WebFilters;
@@ -57,10 +58,12 @@ class WebHandler extends AbstractHandler
     private $state;
 
     /**
+     * WebHandler constructor.
      * @param ParameterResolverInterface $parameterResolver
      * @param SearchEngine $searchEngineHelper
      * @param StoreManagerInterface $storeManager
      * @param NostoHelperAccount $nostoHelperAccount
+     * @param CmpHelperData $cmpHelperData
      * @param StateAwareCategoryServiceInterface $categoryService
      * @param WebFilters $filters
      * @param State $state
@@ -71,6 +74,7 @@ class WebHandler extends AbstractHandler
         SearchEngine $searchEngineHelper,
         StoreManagerInterface $storeManager,
         NostoHelperAccount $nostoHelperAccount,
+        CmpHelperData $cmpHelperData,
         StateAwareCategoryServiceInterface $categoryService,
         WebFilters $filters,
         State $state,
@@ -81,6 +85,7 @@ class WebHandler extends AbstractHandler
             $searchEngineHelper,
             $storeManager,
             $nostoHelperAccount,
+            $cmpHelperData,
             $categoryService,
             $logger
         );

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -63,6 +63,15 @@
                     </comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="fallback_sorting" translate="label comment" type="select" sortOrder="130"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Fallback sorting</label>
+                    <comment>
+                        <![CDATA[Add all categories in the script mapping]]>
+                    </comment>
+                    <source_model>Nosto\Cmp\Model\Config\Source\FallbackSorting</source_model>
+                </field>
+
             </group>
             <group id="limit" translate="label" type="text" sortOrder="20" showInDefault="1"
                    showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -42,6 +42,7 @@
             <flags>
                 <category_sorting>0</category_sorting>
                 <map_all_categories>0</map_all_categories>
+                <fallback_sorting>position</fallback_sorting>
             </flags>
             <limit>
                 <max_products>250</max_products>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a fallback sorting option in case no products are returned by Nosto. 

This feature will only be working with Elasticsearch implementation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
