### PR TITLE
Set total to SearchResult

### DIFF
--- a/Plugin/Catalog/Block/AbstractBlock.php
+++ b/Plugin/Catalog/Block/AbstractBlock.php
@@ -89,6 +89,7 @@ abstract class AbstractBlock extends Template
      * @param NostoCmpHelperData $nostoCmpHelperData
      * @param NostoHelperAccount $nostoHelperAccount
      * @param StateAwareCategoryServiceInterface $categoryService
+     * @param SearchEngine $searchEngineHelper
      * @param LoggerInterface $logger
      */
     public function __construct(

--- a/Plugin/Catalog/Block/AbstractBlock.php
+++ b/Plugin/Catalog/Block/AbstractBlock.php
@@ -44,6 +44,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Theme\Block\Html\Pager as MagentoPager;
 use Nosto\Cmp\Helper\CategorySorting as NostoHelperSorting;
 use Nosto\Cmp\Helper\Data as NostoCmpHelperData;
+use Nosto\Cmp\Helper\SearchEngine;
 use Nosto\Cmp\Model\Service\Recommendation\StateAwareCategoryService;
 use Nosto\Cmp\Model\Service\Recommendation\StateAwareCategoryServiceInterface;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
@@ -51,6 +52,10 @@ use Nosto\Cmp\Logger\LoggerInterface;
 
 abstract class AbstractBlock extends Template
 {
+
+    /** @var SearchEngine */
+    protected $searchEngineHelper;
+
     /** @var int */
     private $lastPageNumber;
 
@@ -92,6 +97,7 @@ abstract class AbstractBlock extends Template
         NostoCmpHelperData $nostoCmpHelperData,
         NostoHelperAccount $nostoHelperAccount,
         StateAwareCategoryServiceInterface $categoryService,
+        SearchEngine $searchEngineHelper,
         LoggerInterface $logger
     ) {
         $this->categoryService = $categoryService;
@@ -100,6 +106,7 @@ abstract class AbstractBlock extends Template
         $this->nostoHelperAccount = $nostoHelperAccount;
         $this->logger = $logger;
         $this->storeManager = $context->getStoreManager();
+        $this->searchEngineHelper = $searchEngineHelper;
         parent::__construct($context);
     }
 
@@ -175,7 +182,7 @@ abstract class AbstractBlock extends Template
      */
     public function afterGetFirstNum($block, $result)
     {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             $pageSize = $block->getCollection()->getPageSize();
             $currentPage = $this->getCurrentPageNumber();
             return $pageSize * ($currentPage - 1) + 1;
@@ -192,7 +199,7 @@ abstract class AbstractBlock extends Template
      */
     public function afterGetLastNum($block, $result)
     {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             $pageSize = $block->getCollection()->getPageSize();
             $currentPage = $this->getCurrentPageNumber();
             $totalResultOfPage = $block->getCollection()->getSize();
@@ -209,7 +216,7 @@ abstract class AbstractBlock extends Template
      */
     public function afterGetTotalNum($block, $result) // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
     {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             return $this->getTotalProducts();
         }
         return $result;
@@ -223,7 +230,7 @@ abstract class AbstractBlock extends Template
      */
     public function afterGetLastPageNum($block, $result) // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
     {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             return $this->getLastPageNumber();
         }
         return $result;

--- a/Plugin/Catalog/Block/Pager.php
+++ b/Plugin/Catalog/Block/Pager.php
@@ -54,6 +54,7 @@ class Pager extends AbstractBlock
      * @param NostoHelperAccount $nostoHelperAccount
      * @param ParameterResolverInterface $parameterResolver
      * @param StateAwareCategoryServiceInterface $categoryService
+     * @param SearchEngine $searchEngineHelper
      * @param LoggerInterface $logger
      */
     public function __construct(

--- a/Plugin/Catalog/Block/Pager.php
+++ b/Plugin/Catalog/Block/Pager.php
@@ -39,6 +39,7 @@ namespace Nosto\Cmp\Plugin\Catalog\Block;
 use Magento\Backend\Block\Template\Context;
 use Magento\Theme\Block\Html\Pager as MagentoPager;
 use Nosto\Cmp\Helper\Data as NostoCmpHelperData;
+use Nosto\Cmp\Helper\SearchEngine;
 use Nosto\Cmp\Logger\LoggerInterface;
 use Nosto\Cmp\Model\Service\Recommendation\StateAwareCategoryServiceInterface;
 use Nosto\Tagging\Helper\Account as NostoHelperAccount;
@@ -61,6 +62,7 @@ class Pager extends AbstractBlock
         NostoHelperAccount $nostoHelperAccount,
         ParameterResolverInterface $parameterResolver,
         StateAwareCategoryServiceInterface $categoryService,
+        SearchEngine $searchEngineHelper,
         LoggerInterface $logger
     ) {
         parent::__construct(
@@ -69,6 +71,7 @@ class Pager extends AbstractBlock
             $nostoCmpHelperData,
             $nostoHelperAccount,
             $categoryService,
+            $searchEngineHelper,
             $logger
         );
     }
@@ -86,7 +89,7 @@ class Pager extends AbstractBlock
         $result,
         $param
     ) {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             return $this->getCurrentPageNumber() === (int)$param;
         }
         return $result;
@@ -104,7 +107,7 @@ class Pager extends AbstractBlock
      */
     public function afterGetFramePages(MagentoPager $pager, $result)
     {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             $start = 0;
             $end = 0;
             $frameLength = $pager->getFrameLength();
@@ -145,7 +148,7 @@ class Pager extends AbstractBlock
         MagentoPager $pager,
         $result
     ) {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             return $this->getCurrentPageNumber() === 1;
         }
         return $result;
@@ -162,7 +165,7 @@ class Pager extends AbstractBlock
         MagentoPager $pager,
         $result
     ) {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             return $this->getLastPageNumber() === $this->getCurrentPageNumber();
         }
         return $result;
@@ -176,7 +179,7 @@ class Pager extends AbstractBlock
      */
     public function afterGetNextPageUrl(MagentoPager $pager, $result)
     {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             return $pager->getPageUrl((string)($this->getCurrentPageNumber() + 1));
         }
         return $result;
@@ -190,7 +193,7 @@ class Pager extends AbstractBlock
      */
     public function afterGetPreviousPageUrl(MagentoPager $pager, $result)
     {
-        if ($this->isCmpTakingOverCatalog()) {
+        if ($this->isCmpTakingOverCatalog() && $this->searchEngineHelper->isMysql()) {
             return $pager->getPageUrl((string)($this->getCurrentPageNumber() - 1));
         }
         return $result;

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -60,8 +60,6 @@ use Zend_Db_Expr;
 
 class Toolbar extends AbstractBlock
 {
-    /** @var SearchEngine */
-    private $searchEngineHelper;
 
     /** @var WebFilters */
     private $filters;
@@ -94,7 +92,6 @@ class Toolbar extends AbstractBlock
         WebFilters $filters,
         State $state
     ) {
-        $this->searchEngineHelper = $searchEngineHelper;
         $this->filters = $filters;
         $this->state = $state;
         parent::__construct(
@@ -103,6 +100,7 @@ class Toolbar extends AbstractBlock
             $nostoCmpHelperData,
             $nostoHelperAccount,
             $categoryService,
+            $searchEngineHelper,
             $logger
         );
     }

--- a/Plugin/Framework/Search/Search.php
+++ b/Plugin/Framework/Search/Search.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Cmp\Plugin\Framework\Search;
+
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Search\Search as MagentoSearch;
+use Nosto\Cmp\Model\Service\Recommendation\StateAwareCategoryServiceInterface;
+
+class Search
+{
+    /**
+     * @var StateAwareCategoryServiceInterface
+     */
+    private $categoryService;
+
+    /**
+     * Search constructor.
+     * @param StateAwareCategoryServiceInterface $categoryService
+     */
+    public function __construct(StateAwareCategoryServiceInterface $categoryService)
+    {
+        $this->categoryService = $categoryService;
+    }
+
+    /**
+     * @param MagentoSearch $search
+     * @param SearchResultInterface $result
+     * @return SearchResultInterface
+     */
+    public function afterSearch(MagentoSearch $search, $result)
+    {
+        $count = $this->getCmpTotalCount();
+        if ($count != null) {
+            $result->setTotalCount($count);
+        }
+        return $result;
+    }
+
+    /**
+     * Returns the product ids sorted by Nosto
+     * @return int|null
+     */
+    private function getCmpTotalCount()
+    {
+        $categoryMerchandisingResult = $this->categoryService->getLastResult();
+        if ($categoryMerchandisingResult !== null) {
+           return $categoryMerchandisingResult->getTotalPrimaryCount();
+        }
+        return null;
+    }
+
+}

--- a/Plugin/Framework/Search/Search.php
+++ b/Plugin/Framework/Search/Search.php
@@ -60,6 +60,7 @@ class Search
      * @param MagentoSearch $search
      * @param SearchResultInterface $result
      * @return SearchResultInterface
+     * @noinspection PhpUnusedParameterInspection
      */
     // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
     public function afterSearch(MagentoSearch $search, $result)

--- a/Plugin/Framework/Search/Search.php
+++ b/Plugin/Framework/Search/Search.php
@@ -61,6 +61,7 @@ class Search
      * @param SearchResultInterface $result
      * @return SearchResultInterface
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
     public function afterSearch(MagentoSearch $search, $result)
     {
         $count = $this->getCmpTotalCount();
@@ -78,9 +79,8 @@ class Search
     {
         $categoryMerchandisingResult = $this->categoryService->getLastResult();
         if ($categoryMerchandisingResult !== null) {
-           return $categoryMerchandisingResult->getTotalPrimaryCount();
+            return $categoryMerchandisingResult->getTotalPrimaryCount();
         }
         return null;
     }
-
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -59,6 +59,9 @@
     <type name="Magento\Framework\Search\Request\Cleaner">
         <plugin name="nosto_search_results_cleaner" type="Nosto\Cmp\Plugin\Framework\Search\Request\RequestCleaner"/>
     </type>
+    <type name="Magento\Framework\Search\Search">
+        <plugin name="" type="Nosto\Cmp\Plugin\Framework\Search\Search"/>
+    </type>
     <type name="Magento\Framework\Api\Search\SearchResult">
         <plugin name="nosto_search_result_sort" type="Nosto\Cmp\Plugin\Api\Search\SearchResultSorter"/>
     </type>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Override the SearchResult total count by passing the value returned by Nosto CMP result. A few categories were not being displayed in the filters due to M2 comparing total nr of products of subcategory with the collection total, which in CM case is equal to the page size. 
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/CatalogSearch/Model/Layer/Filter/Category.php#L136

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
