### PR TITLE
Remove nosto sort option in case of a search page

### DIFF
--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -81,6 +81,7 @@ class Toolbar extends AbstractBlock
      * @param NostoHelperAccount $nostoHelperAccount
      * @param StateAwareCategoryService $categoryService
      * @param ParameterResolverInterface $parameterResolver
+     * @param Http $request
      * @param Logger $logger
      * @param SearchEngine $searchEngineHelper
      * @param BuildWebFacetService $buildWebFacetService

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -206,7 +206,7 @@ class Toolbar extends AbstractBlock
      */
     private function isCategoryPage()
     {
-        return $this->request->getFullActionName() == 'catalog_product_view';
+        return $this->request->getFullActionName() == 'catalog_category_view';
     }
 
     /**

--- a/Plugin/Catalog/Block/Toolbar.php
+++ b/Plugin/Catalog/Block/Toolbar.php
@@ -40,6 +40,7 @@ use Exception;
 use Magento\Backend\Block\Template\Context;
 use Magento\Catalog\Block\Product\ProductList\Toolbar as MagentoToolbar;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
+use Magento\Framework\App\Request\Http;
 use Magento\Framework\DB\Select;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -68,6 +69,9 @@ class Toolbar extends AbstractBlock
     /** @var BuildWebFacetService */
     private $buildWebFacetService;
 
+    /** @var Http */
+    private $request;
+
     private static $isProcessed = false;
 
     /**
@@ -88,6 +92,7 @@ class Toolbar extends AbstractBlock
         NostoHelperAccount $nostoHelperAccount,
         StateAwareCategoryService $categoryService,
         ParameterResolverInterface $parameterResolver,
+        Http $request,
         Logger $logger,
         SearchEngine $searchEngineHelper,
         BuildWebFacetService $buildWebFacetService,
@@ -95,6 +100,7 @@ class Toolbar extends AbstractBlock
     ) {
         $this->buildWebFacetService = $buildWebFacetService;
         $this->state = $state;
+        $this->request = $request;
         parent::__construct(
             $context,
             $parameterResolver,
@@ -130,7 +136,7 @@ class Toolbar extends AbstractBlock
         }
         /* @var Store $store */
         $store = $this->getStoreManager()->getStore();
-        if ($this->isCmpCurrentSortOrder($store)) {
+        if ($this->isCmpCurrentSortOrder($store) && $this->isCategoryPage()) {
             try {
                 /* @var ProductCollection $subjectCollection */
                 $subjectCollection = $subject->getCollection();
@@ -193,6 +199,14 @@ class Toolbar extends AbstractBlock
             $start,
             $limit
         );
+    }
+
+    /**
+     * @return bool
+     */
+    private function isCategoryPage()
+    {
+        return $this->request->getFullActionName() == 'catalog_product_view';
     }
 
     /**

--- a/Plugin/Framework/Search/Request/AbstractHandler.php
+++ b/Plugin/Framework/Search/Request/AbstractHandler.php
@@ -142,7 +142,7 @@ abstract class AbstractHandler
             $this
         );
         $this->preFetchOps($requestData);
-        $this->cleanUpCmpSort($requestData);
+        Search::cleanUpCmpSort($requestData);
         try {
             $productIds = $this->getCmpProductIds(
                 $this->getFilters($requestData),
@@ -184,16 +184,6 @@ abstract class AbstractHandler
      * @return FacetInterface
      */
     abstract protected function getFilters(array $requestData);
-
-    /**
-     * Removes the Nosto sorting key as it's not indexed
-     *
-     * @param array $requestData
-     */
-    private function cleanUpCmpSort(array &$requestData)
-    {
-        unset($requestData['sort'][Search::findNostoSortingIndex($requestData)]);
-    }
 
     /**
      * Set fallback sort order

--- a/Plugin/Framework/Search/Request/RequestCleaner.php
+++ b/Plugin/Framework/Search/Request/RequestCleaner.php
@@ -92,6 +92,8 @@ class RequestCleaner
                 $requestData,
                 $this
             );
+            //remove nosto_personalised in case it's a search page
+            Search::cleanUpCmpSort($requestData);
             return $requestData;
         }
         try {

--- a/Utils/Search.php
+++ b/Utils/Search.php
@@ -74,4 +74,14 @@ class Search
         }
         return null;
     }
+
+    /**
+     * Removes the Nosto sorting key as it's not indexed
+     *
+     * @param array $requestData
+     */
+    public static function cleanUpCmpSort(array &$requestData)
+    {
+        unset($requestData['sort'][Search::findNostoSortingIndex($requestData)]);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CM code is being executed also on the search page. This is not a desired behaviour, as it does not include a specific category. Added a check to avoid execution in search page for both configurations ES and MySQL

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
