### PR TITLE
Pass platform and module version as user agent

### DIFF
--- a/Model/Service/Recommendation/Category.php
+++ b/Model/Service/Recommendation/Category.php
@@ -70,6 +70,8 @@ class Category
 
     /**
      * @param ManagerInterface $eventManager
+     * @param CmHelperData $cmHelperData
+     * @param NostoHelperData $nostoHelperData
      */
     public function __construct(
         ManagerInterface $eventManager,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to make debugging easier in the future, the module should pass the magento and the module version in the GraphQl request headers.

## Related Issue
closes #125 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
