### PR TITLE
Hotfix 3.3.1 - Fix CM sorting issue for Magento's GraphQl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.3.1
+* Fix sorting for CM result served through Magento's GraphQl
+
 ### 3.3.0
 * Fix incorrect products number in filters
 * Add support for subcategory filtering

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -66,6 +66,7 @@ class ProductSearch extends MagentoProductSearch
      * @param SearchResultsInterface $result
      * @return SearchResultsInterface
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
     public function afterGetList(MagentoProductSearch $productSearch, SearchResultsInterface $result)
     {
         $cmp = $this->getCmpSort();

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -42,7 +42,7 @@ use Nosto\Cmp\Model\Service\Recommendation\StateAwareCategoryServiceInterface;
 use Nosto\Cmp\Utils\CategoryMerchandising;
 
 /**
- * Class used to re-sort products
+ * Class used to re-sort products when served through Magento's GraphQl
  */
 class ProductSearch extends MagentoProductSearch
 {

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright (c) 2020, Nosto Solutions Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Nosto Solutions Ltd <contact@nosto.com>
+ * @copyright 2020 Nosto Solutions Ltd
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ *
+ */
+
+namespace Nosto\Cmp\Plugin\CatalogGraphQl\Products\DataProvider;
+
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch as MagentoProductSearch;
+use Magento\Framework\Api\SearchResultsInterface;
+use Nosto\Cmp\Model\Service\Recommendation\StateAwareCategoryServiceInterface;
+use Nosto\Cmp\Utils\CategoryMerchandising;
+
+/**
+ * Class used to re-sort products
+ */
+class ProductSearch extends MagentoProductSearch
+{
+    /**
+     * @var StateAwareCategoryServiceInterface
+     */
+    private $categoryService;
+
+    /**
+     * SearchResultSorter constructor.
+     * @param StateAwareCategoryServiceInterface $categoryService
+     */
+    public function __construct(
+        StateAwareCategoryServiceInterface $categoryService
+    ) {
+        $this->categoryService = $categoryService;
+    }
+
+    /**
+     * @param MagentoProductSearch $productSearch
+     * @param SearchResultsInterface $result
+     * @return SearchResultsInterface
+     */
+    public function afterGetList(MagentoProductSearch $productSearch, SearchResultsInterface $result)
+    {
+        $cmp = $this->getCmpSort();
+        if (!empty($cmp)) {
+            $items = $result->getItems();
+            $newSorting = [];
+            foreach ($cmp as $productId) {
+                //the items are represented as a key value pair array, the key is the product id
+                if (array_key_exists($productId, $items)) {
+                    $newSorting[$productId] = $items[$productId];
+                }
+            }
+            $result->setItems($newSorting);
+        }
+        return $result;
+    }
+
+    /**
+     * Returns the product ids sorted by Nosto
+     * @return int[]|null
+     */
+    private function getCmpSort()
+    {
+        $categoryMerchandisingResult = $this->categoryService->getLastResult();
+        if ($categoryMerchandisingResult !== null) {
+            return CategoryMerchandising::parseProductIds(
+                $categoryMerchandisingResult
+            );
+        }
+        return null;
+    }
+}

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpUnusedParameterInspection */
 /**
  * Copyright (c) 2020, Nosto Solutions Ltd
  * All rights reserved.
@@ -44,7 +44,7 @@ use Nosto\Cmp\Utils\CategoryMerchandising;
 /**
  * Class used to re-sort products when served through Magento's GraphQl
  */
-class ProductSearch extends MagentoProductSearch
+class ProductSearch
 {
     /**
      * @var StateAwareCategoryServiceInterface

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -85,7 +85,7 @@ class ProductSearch
     }
 
     /**
-     * Returns the product ids sorted by Nosto 
+     * Returns the product ids sorted by Nosto
      * or null in case CM is not applied or does not return any results
      * @return int[]|null
      */

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -85,7 +85,8 @@ class ProductSearch
     }
 
     /**
-     * Returns the product ids sorted by Nosto
+     * Returns the product ids sorted by Nosto 
+     * or null in case CM is not applied or does not return any results
      * @return int[]|null
      */
     private function getCmpSort()

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.1.2",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -74,6 +74,9 @@
     <type name="Magento\CatalogGraphQl\Model\Resolver\Products\Query\Search">
         <plugin name="nosto_graphql_products_query" type="Nosto\Cmp\Plugin\CatalogGraphQl\Products\Query\Search"/>
     </type>
+    <type name="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch">
+        <plugin name="nosto_graphql_products_search" type="Nosto\Cmp\Plugin\CatalogGraphQl\Products\DataProvider\ProductSearch"/>
+    </type>
     <type name="Nosto\Cmp\Plugin\Catalog\Block\Toolbar">
         <arguments>
             <argument name="pageSize" xsi:type="number">-1</argument>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="3.3.0">
+    <module name="Nosto_Cmp" setup_version="3.3.1">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The results set which is fetched from ES is sorted again when using Magento's GraphQl as a delivery channel.
Fix this by resorting the products again. 

## Related Issue
closes #142 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
