### PR TITLE
Refactor StateAwareCategoryService::getPersonalisationResult() not to return null

### DIFF
--- a/Model/Service/Recommendation/StateAwareCategoryService.php
+++ b/Model/Service/Recommendation/StateAwareCategoryService.php
@@ -247,7 +247,7 @@ class StateAwareCategoryService implements StateAwareCategoryServiceInterface
     /**
      * @inheritDoc
      */
-    public function getLastResult(): ?CategoryMerchandisingResult
+    public function getLastResult(): CategoryMerchandisingResult
     {
         return $this->lastResult;
     }

--- a/Model/Service/Recommendation/StateAwareCategoryService.php
+++ b/Model/Service/Recommendation/StateAwareCategoryService.php
@@ -101,9 +101,9 @@ class StateAwareCategoryService implements StateAwareCategoryServiceInterface
     private $categoryBuilder;
 
     /**
-     * @var CategoryMerchandisingResult|null
+     * @var CategoryMerchandisingResult
      */
-    private $lastResult = null;
+    private $lastResult;
 
     /**
      * @var int

--- a/Model/Service/Recommendation/StateAwareCategoryServiceInterface.php
+++ b/Model/Service/Recommendation/StateAwareCategoryServiceInterface.php
@@ -56,7 +56,7 @@ interface StateAwareCategoryServiceInterface
     ): ?CategoryMerchandisingResult;
 
     /**
-     * @return CategoryMerchandisingResult|null
+     * @return CategoryMerchandisingResult
      */
     public function getLastResult(): ?CategoryMerchandisingResult;
 

--- a/Model/Service/Recommendation/StateAwareCategoryServiceInterface.php
+++ b/Model/Service/Recommendation/StateAwareCategoryServiceInterface.php
@@ -58,7 +58,7 @@ interface StateAwareCategoryServiceInterface
     /**
      * @return CategoryMerchandisingResult
      */
-    public function getLastResult(): ?CategoryMerchandisingResult;
+    public function getLastResult(): CategoryMerchandisingResult;
 
     /**
      * @param $id

--- a/Plugin/Api/Search/SearchResultSorter.php
+++ b/Plugin/Api/Search/SearchResultSorter.php
@@ -97,17 +97,14 @@ class SearchResultSorter
 
     /**
      * Returns the product ids sorted by Nosto
-     * @return int[]|null
+     * @return int[]
      */
     private function getCmpSort()
     {
         $categoryMerchandisingResult = $this->categoryService->getLastResult();
-        if ($categoryMerchandisingResult !== null) {
-            return CategoryMerchandising::parseProductIds(
-                $categoryMerchandisingResult
-            );
-        }
-        return null;
+        return CategoryMerchandising::parseProductIds(
+            $categoryMerchandisingResult
+        );
     }
 
     /**
@@ -117,9 +114,6 @@ class SearchResultSorter
     private function getTotalPrimaryCount()
     {
         $categoryMerchandisingResult = $this->categoryService->getLastResult();
-        if ($categoryMerchandisingResult !== null) {
-            return $categoryMerchandisingResult->getTotalPrimaryCount();
-        }
-        return null;
+        return $categoryMerchandisingResult->getTotalPrimaryCount();
     }
 }

--- a/Plugin/Catalog/Block/AbstractBlock.php
+++ b/Plugin/Catalog/Block/AbstractBlock.php
@@ -148,9 +148,7 @@ abstract class AbstractBlock extends Template
     public function isCmpTakingOverCatalog()
     {
         $categoryMerchandisingResult = $this->getCategoryService()->getLastResult();
-        if ($categoryMerchandisingResult !== null
-            && !empty($categoryMerchandisingResult->getTrackingCode())
-        ) {
+        if (!empty($categoryMerchandisingResult->getTrackingCode())) {
             return true;
         }
         return false;
@@ -168,14 +166,11 @@ abstract class AbstractBlock extends Template
     }
 
     /**
-     * @return int|null
+     * @return int
      */
     public function getTotalProducts()
     {
-        if ($this->getCategoryService()->getLastResult() !== null) {
-            return $this->getCategoryService()->getLastResult()->getTotalPrimaryCount();
-        }
-        return null;
+        return $this->getCategoryService()->getLastResult()->getTotalPrimaryCount();
     }
 
     /**

--- a/Plugin/Catalog/Block/ListProduct.php
+++ b/Plugin/Catalog/Block/ListProduct.php
@@ -71,16 +71,14 @@ class ListProduct
         Collection $collection
     ) {
         $categoryMerchandisingResult = $this->categoryService->getLastResult();
+        $cmpProductIds = CategoryMerchandising::parseProductIds($categoryMerchandisingResult);
 
-        if ($categoryMerchandisingResult != null) {
-            $cmpProductIds = CategoryMerchandising::parseProductIds($categoryMerchandisingResult);
-            $collection->each(static function ($product) use ($cmpProductIds) {
-                /* @var Product $product */
-                if (in_array($product->getId(), $cmpProductIds)) {
-                    $product->setData(NostoProductPlugin::NOSTO_TRACKING_PARAMETER_NAME, true);
-                }
-            });
-        }
+        $collection->each(static function ($product) use ($cmpProductIds) {
+            /* @var Product $product */
+            if (in_array($product->getId(), $cmpProductIds)) {
+                $product->setData(NostoProductPlugin::NOSTO_TRACKING_PARAMETER_NAME, true);
+            }
+        });
         return $collection;
     }
 }

--- a/Plugin/Framework/Search/Request/AbstractHandler.php
+++ b/Plugin/Framework/Search/Request/AbstractHandler.php
@@ -132,36 +132,6 @@ abstract class AbstractHandler
 
     /**
      * @param array $requestData
-     * @return void
-     * @noinspection PhpRedundantCatchClauseInspection
-     */
-    public function setEmptyCmpProducts(array &$requestData)
-    {
-        $this->preFetchOps($requestData);
-        Search::cleanUpCmpSort($requestData);
-
-        $storeId = $this->getStoreId($requestData);
-        $store = $this->nostoHelperScope->getStore($storeId);
-
-        try {
-            $this->getCmpProductIds(
-                $this->getFilters($store, $requestData),
-                $this->parsePageNumber($store, $requestData),
-                $this->parseLimit($store, $requestData)
-            );
-        } catch (CmpException $e) {
-            $this->exception($e);
-            $this->setFallbackSort($store, $requestData);
-            return;
-        } catch (Exception $e) {
-            $this->exception($e);
-            $this->setFallbackSort($store, $requestData);
-            return;
-        }
-    }
-
-    /**
-     * @param array $requestData
      * @param bool $doLog
      * @return void
      * @noinspection PhpRedundantCatchClauseInspection

--- a/Plugin/Framework/Search/Request/RequestCleaner.php
+++ b/Plugin/Framework/Search/Request/RequestCleaner.php
@@ -89,17 +89,19 @@ class RequestCleaner
     // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
     public function afterClean(Cleaner $cleaner, array $requestData)
     {
+        $doLog = true;
         if (!Search::isNostoSorting($requestData) || !Search::hasCategoryFilter($requestData)) {
             $this->trace('Nosto sorting not used or not found from request data', [], $requestData);
             //remove nosto_personalised in case it's a search page
             Search::cleanUpCmpSort($requestData);
-            return $requestData;
+            // No need to log if Nosto sorting is not used
+            $doLog = false;
         }
 
         if ($this->containsCatalogViewQueries($requestData)) {
-            $this->webHandler->handle($requestData);
+            $this->webHandler->handle($requestData, $doLog);
         } elseif ($this->containsGraphQlProductSearchQueries($requestData)) {
-            $this->graphqlHandler->handle($requestData);
+            $this->graphqlHandler->handle($requestData, $doLog);
         } else {
             $this->trace('Could not find %s from ES request data', [self::KEY_BIND_TO_QUERY]);
         }

--- a/Plugin/Framework/Search/Search.php
+++ b/Plugin/Framework/Search/Search.php
@@ -79,9 +79,6 @@ class Search
     private function getCmpTotalCount()
     {
         $categoryMerchandisingResult = $this->categoryService->getLastResult();
-        if ($categoryMerchandisingResult !== null) {
-            return $categoryMerchandisingResult->getTotalPrimaryCount();
-        }
-        return null;
+        return $categoryMerchandisingResult->getTotalPrimaryCount();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactor StateAwareCategoryService::getPersonalisationResult() not to return null

## Description
Remove null checks and init StateAwareCategoryService::lastResult to be of type CategoryMerchandisingResult even if Nosto Sorting is not used.
<!--- Describe your changes -->

## Related Issue
Closes #138
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Remove extra if checks
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
