### PR TITLE
Set total page count to searchResult value instead of calculating manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.3.2
+* Fix category page issue on GraphQl when merchandising is not enabled
+
 ### 3.3.1
 * Fix sorting for CM result served through Magento's GraphQl
 

--- a/Plugin/CatalogGraphQl/Products/Query/Search.php
+++ b/Plugin/CatalogGraphQl/Products/Query/Search.php
@@ -98,16 +98,30 @@ class Search
         SearchResult  $searchResult,
         array $args
     ) {
-        if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])) {
+        if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])
+            && $this->getTotalPages() != 0) {
             return $this->searchResultFactory->create([
                 'totalCount' => $searchResult->getTotalCount(),
                 'productsSearchResult' => $searchResult->getProductsSearchResult(),
                 'searchAggregation' => $searchResult->getSearchAggregation(),
                 'pageSize' => $searchResult->getPageSize(),
                 'currentPage' => $searchResult->getCurrentPage(),
-                'totalPages' => $searchResult->getTotalCount(),
+                'totalPages' => $this->getTotalPages(),
             ]);
         }
         return $searchResult;
+    }
+
+    /**
+     * Returns 0 when there are no results, also includes the case CM is not enabled for a category
+     * @return int
+     */
+    private function getTotalPages()
+    {
+        $batchModel = $this->sessionService->getBatchModel();
+        if ($batchModel === null) {
+            return 0;
+        }
+        return (int) ceil($batchModel->getTotalCount() / $batchModel->getLastUsedLimit());
     }
 }

--- a/Plugin/CatalogGraphQl/Products/Query/Search.php
+++ b/Plugin/CatalogGraphQl/Products/Query/Search.php
@@ -98,29 +98,16 @@ class Search
         SearchResult  $searchResult,
         array $args
     ) {
-        if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])
-            && $this->getTotalPages() !== null) {
+        if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])) {
             return $this->searchResultFactory->create([
                 'totalCount' => $searchResult->getTotalCount(),
                 'productsSearchResult' => $searchResult->getProductsSearchResult(),
                 'searchAggregation' => $searchResult->getSearchAggregation(),
                 'pageSize' => $searchResult->getPageSize(),
                 'currentPage' => $searchResult->getCurrentPage(),
-                'totalPages' => $this->getTotalPages(),
+                'totalPages' => $searchResult->getTotalCount(),
             ]);
         }
         return $searchResult;
-    }
-
-    /**
-     * @return int|null
-     */
-    private function getTotalPages()
-    {
-        $batchModel = $this->sessionService->getBatchModel();
-        if ($batchModel === null) {
-            return null;
-        }
-        return (int) ceil($batchModel->getTotalCount() / $batchModel->getLastUsedLimit());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.1.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="3.3.1">
+    <module name="Nosto_Cmp" setup_version="3.3.2">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If you request a category page that does not have CMP enabled with sorting set to `nosto_personalized` the error will be returned stating: 

**"currentPage value %1 specified is greater than the %2 page(s) available."**

This is due to the error in `Magento\CatalogGraphQl\Model\Resolver\Products::61` where `$searchResult->getCurrentPage()` is 1 and $searchResult->getTotalPages() is 0 because Nosto manually sets the total pages value to 0 in the plugin. I have removed the manual overriding of the total pages value and it is now fetched from the searchResult object.

Example of a query:
`{
    "query": "{ products( filter: { category_id: { eq: \"12\" } }, currentPage: 1, pageSize: 20 sort: {nosto_personalized: ASC} ) {  items { name } } }"
}`
<!--- Describe your changes -->

## Related Issue
-
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix error for CMP on GraphQL for default categories with Nosto sorting
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally, postman, Magento 2.4.3
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
