### PR TITLE
Add fallback sorting for GraphQl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.3.3
+* Fix fallback sorting issue on GraphQl when merchandising is not enabled
+
 ### 3.3.2
 * Fix category page issue on GraphQl when merchandising is not enabled
 

--- a/Plugin/CatalogGraphQl/Products/Query/Search.php
+++ b/Plugin/CatalogGraphQl/Products/Query/Search.php
@@ -41,7 +41,9 @@ use Magento\CatalogGraphQl\Model\Resolver\Products\Query\Search as MagentoSearch
 use Magento\CatalogGraphQl\Model\Resolver\Products\SearchResult;
 use Magento\CatalogGraphQl\Model\Resolver\Products\SearchResultFactory;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\ContextInterface;
 use Nosto\Cmp\Helper\CategorySorting;
+use Nosto\Cmp\Helper\Data as CmpHelperData;
 use Nosto\Cmp\Model\Service\Recommendation\GraphQlParamModel;
 use Nosto\Cmp\Model\Service\Recommendation\SessionService;
 
@@ -57,33 +59,45 @@ class Search
     /** @var SessionService */
     private $sessionService;
 
+    /** @var CmpHelperData */
+    private $cmpHelperData;
+
     /**
      * Search constructor.
      * @param SearchResultFactory $searchResultFactory
      * @param SessionService $sessionService
+     * @param CmpHelperData $cmpHelperData
      */
     public function __construct(
         SearchResultFactory $searchResultFactory,
-        SessionService $sessionService
+        SessionService $sessionService,
+        CmpHelperData $cmpHelperData
     ) {
         $this->searchResultFactory =  $searchResultFactory;
         $this->sessionService = $sessionService;
+        $this->cmpHelperData = $cmpHelperData;
     }
 
     /**
      * @param MagentoSearch $search
      * @param array $args
      * @param ResolveInfo $info
+     * @param ContextInterface $context
+     * @return array
      * @noinspection PhpUnusedParameterInspection
      */
     // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
-    public function beforeGetResult(MagentoSearch $search, array $args, ResolveInfo $info)
+    public function beforeGetResult(MagentoSearch $search, array $args, ResolveInfo $info, ContextInterface $context)
     {
         if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])) {
             $pageSize = $args[self::PAGE_SIZE_KEY];
             $currentPage = $args[self::CURRENT_PAGE_KEY];
             $this->sessionService->setGraphqlModel(new GraphQlParamModel($pageSize, $currentPage));
+
+            $sorting = $this->cmpHelperData->getFallbackSorting();
+            $args[self::SORT_KEY][$sorting] = 'ASC';
         }
+        return [$args, $info, $context];
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.1.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="3.3.2">
+    <module name="Nosto_Cmp" setup_version="3.3.3">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixing issue where fallback sorting set by a merchant is ignored and default position sorting is applied on categories where CMP is disabled.
## Description
<!--- Describe your changes -->
Add fallback sorting in the search plugin.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fallback sorting needs to work in GraphQL
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
