### PR TITLE
Hotfix/4.0.1 - Fix CM GraphQl pagination issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 4.0.1
+* Fix empty results issues on Magento's GraphQl pagination
+
 ### 4.0.0
 * Remove support for MySQL as search engine
 * Move CategoryMerchandising util to php-sdk

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -37,7 +37,9 @@
 namespace Nosto\Cmp\Plugin\CatalogGraphQl\Products\DataProvider;
 
 use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch as MagentoProductSearch;
+use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Api\SearchResultsInterface;
+use Nosto\Cmp\Helper\CategorySorting;
 use Nosto\Cmp\Model\Service\Merchandise\LastResult;
 
 /**
@@ -55,6 +57,20 @@ class ProductSearch
         LastResult $lastResult
     ) {
         $this->lastResult = $lastResult;
+    }
+
+    /**
+     * @param MagentoProductSearch $productSearch
+     * @param SearchCriteriaInterface $searchCriteria
+     */
+    public function beforeGetList(MagentoProductSearch $productSearch, SearchCriteriaInterface $searchCriteria)
+    {
+        //Set currentPage to 1, this will make sure that OFFSET is not applied to the MySQL query
+        foreach ($searchCriteria->getSortOrders() as $sortOrder) {
+            if ($sortOrder->getField() === CategorySorting::NOSTO_PERSONALIZED_KEY) {
+                $searchCriteria->setCurrentPage(1);
+            }
+        }
     }
 
     /**

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -63,6 +63,7 @@ class ProductSearch
      * @param MagentoProductSearch $productSearch
      * @param SearchCriteriaInterface $searchCriteria
      */
+    // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
     public function beforeGetList(MagentoProductSearch $productSearch, SearchCriteriaInterface $searchCriteria)
     {
         //Set currentPage to 1, this will make sure that OFFSET is not applied to the MySQL query

--- a/Plugin/CatalogGraphQl/Products/Query/Search.php
+++ b/Plugin/CatalogGraphQl/Products/Query/Search.php
@@ -115,7 +115,7 @@ class Search
         if (isset($args[self::SORT_KEY]) && isset($args[self::SORT_KEY][CategorySorting::NOSTO_PERSONALIZED_KEY])
             && $this->getTotalPages() != 0) {
             return $this->searchResultFactory->create([
-                'totalCount' => $searchResult->getTotalCount(),
+                'totalCount' => $this->getTotalCount(),
                 'productsSearchResult' => $searchResult->getProductsSearchResult(),
                 'searchAggregation' => $searchResult->getSearchAggregation(),
                 'pageSize' => $searchResult->getPageSize(),
@@ -137,5 +137,17 @@ class Search
             return 0;
         }
         return (int) ceil($batchModel->getTotalCount() / $batchModel->getLastUsedLimit());
+    }
+
+    /**
+     * @return int
+     */
+    private function getTotalCount()
+    {
+        $batchModel = $this->sessionService->getBatchModel();
+        if ($batchModel === null) {
+            return 0;
+        }
+        return $batchModel->getTotalCount();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.1.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="4.0.0">
+    <module name="Nosto_Cmp" setup_version="4.0.1">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A pagination issue is happening on Magento's GraphQl. For pages bigger than 1 the result set is empty.
The problem relies in `Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch` , a new collection is created and an `OFFSET` equals to the page size is applied to the MySQL query. 

The offset is removed by setting the page size manually to 1 if nosto_personalized sorting is applied. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
