### PR TITLE
Hotfix 4.0.1 - Fix pagination when CM is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 4.0.2
+* Fix pagination when CM is disabled
+
 ### 4.0.1
 * Fix empty results issues on Magento's GraphQl pagination
 

--- a/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
+++ b/Plugin/CatalogGraphQl/Products/DataProvider/ProductSearch.php
@@ -68,7 +68,7 @@ class ProductSearch
     {
         //Set currentPage to 1, this will make sure that OFFSET is not applied to the MySQL query
         foreach ($searchCriteria->getSortOrders() as $sortOrder) {
-            if ($sortOrder->getField() === CategorySorting::NOSTO_PERSONALIZED_KEY) {
+            if ($sortOrder->getField() === CategorySorting::NOSTO_PERSONALIZED_KEY && $this->getCmpSort() != null) {
                 $searchCriteria->setCurrentPage(1);
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.1.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="4.0.1">
+    <module name="Nosto_Cmp" setup_version="4.0.2">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A bug was introduced in 4.0.1 version. When category merchandising the result for `nosto_personalized` sorting will always be the first page. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
