### PR TITLE
hotfix 5.3.1 - TypeCheck category building string

### DIFF
--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Magento
       id: install-magento
       run: |
-        composer create-project magento/community-edition=2.4.2 magento --no-dev
+        composer create-project magento/community-edition=2.4.5 magento --no-dev
         cd magento
         composer config minimum-stability dev
         composer config prefer-stable true

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -64,7 +64,7 @@ jobs:
         REPO_PSW: ${{ secrets.REPO_PSW }}
 
     - name: Run PHPStorm
-      uses: mridang/action-phpstorm@master
+      uses: supercid/action-phpstorm@master
       with:
         target: .
         profile: ./.idea/inspectionProfiles/CI.xml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Archive inspection results
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: inspection-results
         path: output

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install Magento
       id: install-magento
       run: |
-        composer create-project magento/community-edition=2.4.2 magento --no-dev
+        composer create-project magento/community-edition=2.4.5 magento --no-dev
         cd magento
         composer config minimum-stability dev
         composer config prefer-stable true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 5.3.1
+* Add nullcheck to avoid logging errors when the current category is not a regular Magento Category
+
 ### 5.3.0
 * Improve compatibility with Magento 2.4.6
 

--- a/Exception/InvalidCategoryTypeException.php
+++ b/Exception/InvalidCategoryTypeException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Nosto\Cmp\Exception;
+
+use Magento\Store\Model\Store;
+
+class InvalidCategoryTypeException extends CmpException
+{
+    private const DEFAULT_MESSAGE = "Category is not a valid default Magento category type.";
+
+    /**
+     * @param Store $store
+     */
+    public function __construct(Store $store)
+    {
+        parent::__construct($store, self::DEFAULT_MESSAGE);
+    }
+
+}

--- a/Model/Service/Merchandise/RequestParamsService.php
+++ b/Model/Service/Merchandise/RequestParamsService.php
@@ -40,6 +40,7 @@ use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\Stdlib\CookieManagerInterface;
+use Magento\Catalog\Model\Category;
 use Nosto\Cmp\Exception\MissingAccountException;
 use Nosto\Cmp\Exception\MissingTokenException;
 use Nosto\Cmp\Exception\SessionCreationException;
@@ -224,6 +225,9 @@ class RequestParamsService
     {
         /** @noinspection PhpDeprecationInspection */
         $category = $this->registry->registry('current_category'); //@phan-suppress-current-line PhanDeprecatedFunction
+        if (!$category instanceof Category) {
+            return null;
+        }
         return $this->categoryBuilder->getCategory($category, $store);
     }
 

--- a/Model/Service/Merchandise/RequestParamsService.php
+++ b/Model/Service/Merchandise/RequestParamsService.php
@@ -58,6 +58,7 @@ use Nosto\Tagging\Logger\Logger;
 use Nosto\Tagging\Model\Customer\Customer as NostoCustomer;
 use Nosto\Tagging\Model\Service\Product\Category\DefaultCategoryService as CategoryBuilder;
 use Nosto\Cmp\Model\Service\MagentoSession\SessionService as ResultSessionService;
+use Nosto\Cmp\Exception\InvalidCategoryTypeException;
 
 class RequestParamsService
 {
@@ -219,14 +220,15 @@ class RequestParamsService
     /**
      * Get the current category
      * @param Store $store
-     * @return null|string
+     * @return string
+     * @throws InvalidCategoryTypeException
      */
     private function getCurrentCategoryString(Store $store)
     {
         /** @noinspection PhpDeprecationInspection */
         $category = $this->registry->registry('current_category'); //@phan-suppress-current-line PhanDeprecatedFunction
         if (!$category instanceof Category) {
-            return null;
+            throw new InvalidCategoryTypeException($store);
         }
         return $this->categoryBuilder->getCategory($category, $store);
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nosto/module-nostocmp",
   "description": "Nosto Category Merchandising extension for Magento 2",
   "type": "magento2-module",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "require-dev": {
     "magento-ecg/coding-standard": "3.*",
     "magento/module-store": "101.1.2",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -37,7 +37,7 @@
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Nosto_Cmp" setup_version="5.3.0">
+    <module name="Nosto_Cmp" setup_version="5.3.1">
         <sequence>
             <module name="Nosto_Tagging"/>
         </sequence>


### PR DESCRIPTION
Might cause a lot of errors when custom handled categories are not returned:

```
report.CRITICAL: TypeError: Nosto\Tagging\Model\Service\Product\Category\DefaultCategoryService::getCategory(): Argument #1 ($category) must be of type Magento\Catalog\Model\Category, null given, called in /app/{REDACTED}/vendor/nosto/module-nostotagging-cmp/Model/Service/Merchandise/RequestParamsService.php on line 227 and defined in /app/{REDACTED}/vendor/nosto/module-nostotagging/Model/Service/Product/Category/DefaultCategoryService.php:102```